### PR TITLE
Pruned loci list

### DIFF
--- a/pruned_loci_list.R
+++ b/pruned_loci_list.R
@@ -1,13 +1,12 @@
 #Pull loci from a plink LD pruned loci .map file. Generate a text file that can then be used in VCF tools position filtering.
-setwd("~/Downloads")
+# setwd("~/Downloads")
 library(dplyr)
 dat <- as.data.frame(read.table(file="seq17_03_SNPs.LDpruned.map", header=FALSE))
 dat <- rename(dat, chrom=V1, locus=V2, position=V3, dist=V4)
 
 loci <- dat %>%
 select(locus) %>%
-mutate(locus = stringr::str_replace_all(locus, ":", " ")) # remove the colons, replace with spaces
+mutate(locus = stringr::str_replace_all(locus, "_", " ")) # remove the underscores, replace with spaces
 
 # eliminate header and quotes when writing to file
-# MRS "I'm not sure if these copied and pasted " " are supposed to have a space between them or not"
-write.table(loci, file="data/pruned_loci_list.txt", sep=" ", quote = F, col.names = F, row.names = F) 
+write.table(loci, file="pruned_loci_list.txt", sep=" ", quote = F, col.names = F, row.names = F) 


### PR DESCRIPTION
I added a couple lines to remove the manual work that you were doing in this step of your protocol:

"Generate a list of loci to include because they aren’t pruned out by the link loci. To do this, download the LDpruned.map file and then run it through the pruned_loci_list.R script on Kat’s github. 
    * Once you write the text file, delete the header and the quotes, then regex search and replace (\d+)_(\d+) with \1\s\2 to make the format compatible with the VCF include function
    * Header appears to be the word “locus”, "